### PR TITLE
Standardized Path Names to tel_company_name_module_initials Convention

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -29,7 +29,7 @@
     ],
     'assets': {
             'web.assets_backend': [
-                'craes_security_assets/static/img/icon.png',
+                'tel_cra_sa/static/img/icon.png',
             ],
     },
     'images': ['static/description/icon.png'],

--- a/models/weapon.py
+++ b/models/weapon.py
@@ -138,7 +138,7 @@ class Weapon(models.Model):
         self.env['security.assets.weapon.history'].create({'weapon_id': self.id, 'position_id': position.id, 'movement_type': movement_type, 'movement_date': fields.Datetime.now()})
 
     def action_all_weapons_report(self):
-        return self.env.ref('craes_security_assets.action_all_weapons_report').report_action(self)
+        return self.env.ref('tel_cra_sa.action_all_weapons_report').report_action(self)
 
 class WeaponMovementHistory(models.Model):
     _name = 'security.assets.weapon.history'

--- a/reports/all_weapons_report.xml
+++ b/reports/all_weapons_report.xml
@@ -3,8 +3,8 @@
         <field name="name">Reporte de Armas y Posiciones</field>
         <field name="model">security.assets.weapon</field>
         <field name="report_type">qweb-html</field>
-        <field name="report_name">craes_security_assets.all_weapons_report_template</field>
-        <field name="report_file">craes_security_assets.all_weapons_report_template</field>
+        <field name="report_name">tel_cra_sa.all_weapons_report_template</field>
+        <field name="report_file">tel_cra_sa.all_weapons_report_template</field>
         <field name="print_report_name">'Reporte de Armas - %s' % (object.display_name)</field>
     </record>
 </odoo>

--- a/reports/position_weapons_report.xml
+++ b/reports/position_weapons_report.xml
@@ -3,8 +3,8 @@
         <field name="name">Reporte de Armas por Puesto</field>
         <field name="model">security.assets.facility</field>
         <field name="report_type">qweb-html</field>
-        <field name="report_name">craes_security_assets.position_weapons_report_template</field>
-        <field name="report_file">craes_security_assets.position_weapons_report_template</field>
+        <field name="report_name">tel_cra_sa.position_weapons_report_template</field>
+        <field name="report_file">tel_cra_sa.position_weapons_report_template</field>
         <field name="print_report_name">'Reporte de Armas - %s' % (object.display_name)</field>
     </record>
 </odoo>

--- a/reports/weapon_assignment_report.xml
+++ b/reports/weapon_assignment_report.xml
@@ -3,8 +3,8 @@
         <field name="name">Reporte de Asignación de Arma</field>
         <field name="model">security.assets.position</field>
         <field name="report_type">qweb-html</field>
-        <field name="report_name">craes_security_assets.weapon_assignment_report_template</field>
-        <field name="report_file">craes_security_assets.weapon_assignment_report_template</field>
+        <field name="report_name">tel_cra_sa.weapon_assignment_report_template</field>
+        <field name="report_file">tel_cra_sa.weapon_assignment_report_template</field>
         <field name="print_report_name">'Asignación de Arma - %s' % (object.display_name)</field>
     </record>
 </odoo>

--- a/views/security_assets_facility_view.xml
+++ b/views/security_assets_facility_view.xml
@@ -17,7 +17,7 @@
         <field name="arch" type="xml">
             <form string="Crear Puesto">
                 <header>
-                    <button name="craes_security_assets.action_position_weapons_report" string="Imprimir Reporte de Armas Asignadas" type="action" class="btn-primary"/>
+                    <button name="tel_cra_sa.action_position_weapons_report" string="Imprimir Reporte de Armas Asignadas" type="action" class="btn-primary"/>
                 </header>
                 <sheet>
                     <group>

--- a/views/security_assets_menu.xml
+++ b/views/security_assets_menu.xml
@@ -1,12 +1,12 @@
 <odoo>
-    <menuitem id="security_assets_menu" web_icon="craes_security_assets,static/description/icon.png" name="Activos de Seguridad"/>
-    <menuitem id="agents_group_menu" sequence="1" parent="craes_security_assets.security_assets_menu" name="Agentes"/>
-    <menuitem id="district_manager_menu" parent="craes_security_assets.agents_group_menu" name="Jefes de Distrito" action="district_manager_action"/>
-    <menuitem id="supervisor_menu" parent="craes_security_assets.agents_group_menu" name="Supervisores" action="supervisor_action"/>
-    <menuitem id="facility_menu" parent="craes_security_assets.security_assets_menu" name="Puestos" action="facility_action"/>
-    <menuitem id="position_menu" parent="craes_security_assets.security_assets_menu" name="Ubicaciones" action="position_action"/>
-    <menuitem id="weapons_group_menu" sequence="4" parent="craes_security_assets.security_assets_menu" name="Armamento"/>
-    <menuitem id="brand_menu" parent="craes_security_assets.weapons_group_menu" name="Marcas" action="brand_action"/>
-    <menuitem id="model_menu" parent="craes_security_assets.weapons_group_menu" name="Modelos" action="model_action"/>
-    <menuitem id="weapon_menu" parent="craes_security_assets.weapons_group_menu" name="Armas Asignadas" action="weapons_action"/>
+    <menuitem id="security_assets_menu" web_icon="tel_cra_sa,static/description/icon.png" name="Activos de Seguridad"/>
+    <menuitem id="agents_group_menu" sequence="1" parent="tel_cra_sa.security_assets_menu" name="Agentes"/>
+    <menuitem id="district_manager_menu" parent="tel_cra_sa.agents_group_menu" name="Jefes de Distrito" action="district_manager_action"/>
+    <menuitem id="supervisor_menu" parent="tel_cra_sa.agents_group_menu" name="Supervisores" action="supervisor_action"/>
+    <menuitem id="facility_menu" parent="tel_cra_sa.security_assets_menu" name="Puestos" action="facility_action"/>
+    <menuitem id="position_menu" parent="tel_cra_sa.security_assets_menu" name="Ubicaciones" action="position_action"/>
+    <menuitem id="weapons_group_menu" sequence="4" parent="tel_cra_sa.security_assets_menu" name="Armamento"/>
+    <menuitem id="brand_menu" parent="tel_cra_sa.weapons_group_menu" name="Marcas" action="brand_action"/>
+    <menuitem id="model_menu" parent="tel_cra_sa.weapons_group_menu" name="Modelos" action="model_action"/>
+    <menuitem id="weapon_menu" parent="tel_cra_sa.weapons_group_menu" name="Armas Asignadas" action="weapons_action"/>
 </odoo>

--- a/views/security_assets_position_view.xml
+++ b/views/security_assets_position_view.xml
@@ -16,7 +16,7 @@
         <field name="arch" type="xml">
             <form string="Crear Ubicacion">
                 <header invisible="weapon_id == False">
-                    <button name="craes_security_assets.action_weapon_assignment_report" string="Imprimir Reporte de Armas Asignadas" type="action" class="btn-primary"/>
+                    <button name="tel_cra_sa.action_weapon_assignment_report" string="Imprimir Reporte de Armas Asignadas" type="action" class="btn-primary"/>
                 </header>
                 <sheet>
                     <group>

--- a/views/security_assets_weapon_view.xml
+++ b/views/security_assets_weapon_view.xml
@@ -62,7 +62,7 @@
         <field name="arch" type="xml">
             <list string="Armas">
                 <header>
-                    <button name="craes_security_assets.action_all_weapons_report" string="Imprimir Listado de Armas" type="action" class="btn-primary"/>
+                    <button name="tel_cra_sa.action_all_weapons_report" string="Imprimir Listado de Armas" type="action" class="btn-primary"/>
                 </header>
                 <field name="brand_id"/>
                 <field name="model_id"/>


### PR DESCRIPTION
This pull request introduces a refactor to align the internal structure of the module with a standardized naming convention using the format tel_company_name_module_initials.

Changes Implemented
• Renamed all XML ID references, file paths, and asset registrations to follow the tel_company_name_module_initials format (e.g., tel_exp_sa).
• Updated folder and internal identifiers accordingly for:
• Views
• Menus
• Report actions and templates
• Security access files
• Updated __manifest__.py to reflect consistent naming.
